### PR TITLE
Remote relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,49 +17,50 @@ depending on your Sonos speaker.
 Please note that even when your devices have discovered one another, at
 least in the Sonos case, a unicast connection will be established from
 the speakers back to the controlling-telephone. You will need to make sure
-that IP forwarding is enabled (echo 1 > /proc/sys/net/ipv4/ip_forward) and
+that IP forwarding is enabled (`echo 1 > /proc/sys/net/ipv4/ip_forward`) and
 that no firewalling is in place that would prevent connections being
 established.
 
-usage: multicast-relay.py [-h] --interfaces INTERFACE INTERFACE [INTERFACE ...] [--relay BROADCAST_OR_MULTICAST:PORT [BROADCAST_OR_MULTICAST:PORT ...]] [--noMDNS] [--noSSDP] [--noSonosDiscovery] [--oneInterface] [--homebrewNetifaces] [--wait] [--foreground] [--verbose]
+`usage: multicast-relay.py [-h] --interfaces INTERFACE INTERFACE [INTERFACE ...] [--relay BROADCAST_OR_MULTICAST:PORT [BROADCAST_OR_MULTICAST:PORT ...]] [--noMDNS] [--noSSDP] [--noSonosDiscovery] [--oneInterface] [--homebrewNetifaces] [--wait] [--listen REMOTE_ADDRESS [REMOTE_ADDRESS ...]] [--remote REMOTE_ADDRESS] [--remotePort PORT] [--foreground] [--verbose]`
 
---interfaces specifies the >= 2 interfaces that you desire to listen to and
+`--interfaces` specifies the >= 2 interfaces that you desire to listen to and
 relay between. You can specify an interface by name, by IP address, or by
-network/netmask combination (e.g. 10.0.0.0/24 in the last case).
+network/netmask combination (e.g. 10.0.0.0/24 in the last case). With certain
+flags below, the minimum number of interfaces drops to >= 1.
 
---relay specifies additional broadcast or multicast addresses to relay.
+`--relay` specifies additional broadcast or multicast addresses to relay.
 
---noMDNS disables mDNS relaying.
+`--noMDNS` disables mDNS relaying.
 
---noSSDP disables SSDP relaying.
+`--noSSDP` disables SSDP relaying.
 
---noSonosDiscovery disables broadcast udp/6969 relaying.
+`--noSonosDiscovery` disables broadcast udp/6969 relaying.
 
---oneInterface support for one interface connected to two networks. Use with
+`--oneInterface` support for one interface connected to two networks. Use with
 caution - watch out for packet storms (although the IP checksum list ought
 to still prevent such a thing from happening).
 
---homebrewNetifaces attempt to use our own netifaces implementation, probably
+`--homebrewNetifaces` attempt to use our own netifaces implementation, probably
 doesn't work on any other system than Linux but maybe useful for OpenWRT where
 it's rather tricky to compile up netifaces.
 
---allowNonEther supports non-ethernet interfaces to be relayed [experimental].
+`--allowNonEther` supports non-ethernet interfaces to be relayed [experimental].
 
---wait indicates that the relay should wait for an IPv4 address to be assigned
+`--wait` indicates that the relay should wait for an IPv4 address to be assigned
 to each interface rather than bailing immediately if an interface is yet to be
 assigned an address.
 
---listen A.B.C.D for connections from the specified remote host.
+`--listen` for connections from the specified remote host(s).
 
---remote A.B.C.D connections to the specified remote host. If either --listen or
-    --remote are specified, then one can also specify just one local interface.
+`--remote` connect to the specified remote host. If either --listen or --remote
+are specified, then one can also specify just one local interface with --interfaces.
 
---remotePort PORT use the specified port for remote communications (default: 1900).
+`--remotePort` PORT use the specified port for remote communications (default: 1900).
 
---foreground stops the process forking itself off into the background. This
+`--foreground` stops the process forking itself off into the background. This
 flag also encourages logging to stdout as well as to the syslog.
 
---verbose steps up the logging.
+`--verbose` steps up the logging.
 
 multicast-relay.py requires the python 'netifaces' package. Install via
 'easy_install netifaces' or 'pip install netifaces'. For ZeroShell users,

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ it's rather tricky to compile up netifaces.
 to each interface rather than bailing immediately if an interface is yet to be
 assigned an address.
 
+--listen A.B.C.D for connections from the specified remote host.
+
+--remote A.B.C.D connections to the specified remote host. If either --listen or
+    --remote are specified, then one can also specify just one local interface.
+
+--remotePort PORT use the specified port for remote communications (default: 1900).
+
 --foreground stops the process forking itself off into the background. This
 flag also encourages logging to stdout as well as to the syslog.
 

--- a/multicast-relay.py
+++ b/multicast-relay.py
@@ -284,7 +284,7 @@ class PacketRelay():
                     continue
                 else:
                     if s == self.connection:
-                        (data, addr) = s.recvfrom(10240)
+                        (data, addr) = s.recvfrom(6)
                         if not data:
                             # TODO: attempt reconnection, in a non-blocking fashion of course
                             self.logger.info('REMOTE: Connection closed')
@@ -294,13 +294,14 @@ class PacketRelay():
                             continue
 
                         addr = socket.inet_ntoa(data[0:4])
-                        data = data[4:]
+                        size = struct.unpack('!H', data[4:6])
+                        (data, _) = s.recvfrom(size)
                     else:
                         (data, addr) = s.recvfrom(10240)
                         addr = addr[0]
 
                 if self.connection and s != self.connection:
-                    self.connection.sendall(socket.inet_aton(addr) + data)
+                    self.connection.sendall(socket.inet_aton(addr) + struct.pack('!H', len(data)) + data)
 
                 # Use IP checksum information to see if we have already seen this
                 # packet, since once we have retransmitted it on an interface

--- a/multicast-relay.py
+++ b/multicast-relay.py
@@ -294,7 +294,7 @@ class PacketRelay():
                             continue
 
                         addr = socket.inet_ntoa(data[0:4])
-                        size = struct.unpack('!H', data[4:6])
+                        size = struct.unpack('!H', data[4:6])[0]
                         (data, _) = s.recvfrom(size)
                     else:
                         (data, addr) = s.recvfrom(10240)

--- a/multicast-relay.py
+++ b/multicast-relay.py
@@ -286,6 +286,7 @@ class PacketRelay():
                     if s == self.connection:
                         (data, addr) = s.recvfrom(10240)
                         if not data:
+                            # TODO: attempt reconnection, in a non-blocking fashion of course
                             self.logger.info('REMOTE: Connection closed')
                             s.close()
                             if s == self.connection:
@@ -299,7 +300,7 @@ class PacketRelay():
                         addr = addr[0]
 
                 if self.connection and s != self.connection:
-                      self.connection.sendall(socket.inet_aton(addr) + data)
+                    self.connection.sendall(socket.inet_aton(addr) + data)
 
                 # Use IP checksum information to see if we have already seen this
                 # packet, since once we have retransmitted it on an interface

--- a/multicast-relay.py
+++ b/multicast-relay.py
@@ -284,8 +284,6 @@ class PacketRelay():
                     continue
                 else:
                     (data, addr) = s.recvfrom(10240)
-                    if self.connection and s != self.connection:
-                          self.connection.sendall(data)
 
                 if not data:
                     self.logger.info('REMOTE: Connection closed')
@@ -293,6 +291,9 @@ class PacketRelay():
                     if s == self.connection:
                         self.connection = None
                     continue
+
+                if self.connection and s != self.connection:
+                      self.connection.sendall(data)
 
                 # Use IP checksum information to see if we have already seen this
                 # packet, since once we have retransmitted it on an interface

--- a/multicast-relay.py
+++ b/multicast-relay.py
@@ -276,8 +276,8 @@ class PacketRelay():
             for s in inputready:
                 if s == self.listenSock:
                     (self.connection, remoteAddr) = s.accept()
-                    if remoteAddr[0] != self.listenAddr:
-                        self.logger.info('Refusing connection from %s - not %s' % (remoteAddr[0], self.listenAddr))
+                    if remoteAddr[0] not in self.listenAddr:
+                        self.logger.info('Refusing connection from %s - not in %s' % (remoteAddr[0], self.listenAddr))
                         self.connection.close()
                         self.connection = None
                     self.logger.info('REMOTE: Accepted connection from %s' % remoteAddr[0])
@@ -553,8 +553,8 @@ def main():
                         help='Wait for IPv4 address assignment.')
     parser.add_argument('--ttl', type=int,
                         help='Set TTL on outbound packets.')
-    parser.add_argument('--listen',
-                        help='Listen for a remote connection from remote address A.B.C.D.')
+    parser.add_argument('--listen', nargs='+',
+                        help='Listen for a remote connection from one or more remote addresses A.B.C.D.')
     parser.add_argument('--remote',
                         help='Relay packets to remote multicast-relay on A.B.C.D.')
     parser.add_argument('--remotePort', type=int, default=1900,

--- a/multicast-relay.py
+++ b/multicast-relay.py
@@ -284,7 +284,7 @@ class PacketRelay():
                     continue
                 else:
                     if s == self.connection:
-                        (data, addr) = s.recvfrom(6)
+                        (data, addr) = s.recvfrom(6, socket.MSG_WAITALL)
                         if not data:
                             # TODO: attempt reconnection, in a non-blocking fashion of course
                             self.logger.info('REMOTE: Connection closed')
@@ -295,7 +295,7 @@ class PacketRelay():
 
                         addr = socket.inet_ntoa(data[0:4])
                         size = struct.unpack('!H', data[4:6])[0]
-                        (data, _) = s.recvfrom(size)
+                        (data, _) = s.recvfrom(size, socket.MSG_WAITALL)
                     else:
                         (data, addr) = s.recvfrom(10240)
                         addr = addr[0]

--- a/multicast-relay.py
+++ b/multicast-relay.py
@@ -284,6 +284,8 @@ class PacketRelay():
                     continue
                 else:
                     (data, addr) = s.recvfrom(10240)
+                    if self.connection and s != self.connection:
+                          self.connection.sendall(data)
 
                 if not data:
                     self.logger.info('REMOTE: Connection closed')


### PR DESCRIPTION
Add the ability for two `multicast-relay` instances to communicate with one another over a WAN and relay packets between each side.